### PR TITLE
Fixed the parsing of the xsi:nil attribute, now outputs a JSON object with "null" for the value.

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -223,6 +223,7 @@ public class XML {
             tagName = (String) token;
             token = null;
             jsonobject = new JSONObject();
+            boolean nil = false;
             for (;;) {
                 if (token == null) {
                     token = x.nextToken();
@@ -237,9 +238,14 @@ public class XML {
                         if (!(token instanceof String)) {
                             throw x.syntaxError("Missing value");
                         }
-                        jsonobject.accumulate(string,
-                                JSONObject.stringToValue((String) token));
-                        token = null;
+                        if (string.equals("xsi:nil") && token.equals("true")) {
+                        	context.accumulate(tagName, "null");
+                        	nil = true;
+                        	token = null;
+                        } else {
+                            jsonobject.accumulate(string, JSONObject.stringToValue((String) token));
+                            token = null;                            	
+                        }
                     } else {
                         jsonobject.accumulate(string, "");
                     }
@@ -253,7 +259,11 @@ public class XML {
                     if (jsonobject.length() > 0) {
                         context.accumulate(tagName, jsonobject);
                     } else {
-                        context.accumulate(tagName, "");
+                    	if (nil) {
+                    		nil = false;
+                    	} else {
+                    		context.accumulate(tagName, "");
+                    	}
                     }
                     return false;
 


### PR DESCRIPTION
This change will now allow XML.java to properly convert XML elements with the xsi:nil=true attribute. Previously elements with this attribute would be converted into JSON elements with "xsi:nil" being added as a separate element underneath. For example, consider the following XML:
`<book>
<title>Beowulf</title>
<author xsi:nil="true"/>
</book>`

Previously, this would be converted to the following format:
`{"book": {
  "author": {"xsi:nil": true},
  "title": "Beowulf"
}}`

With this change, the converted JSON will now look like this:
`{"book": {
  "author": "null",
  "title": "Beowulf"
}}`
